### PR TITLE
Update labels and add info metrics, use port 9177 which other libvirt exporters used

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@
 [![Lint Go Code](https://github.com/inovex/prometheus-libvirt-exporter/actions/workflows/lint.yml/badge.svg)](https://github.com/inovex/prometheus-libvirt-exporter/actions/workflows/lint.yml)
 
 A prometheus-[libvirt](https://libvirt.org/)-exporter for host and vm metrics exposed for prometheus, written in Go with pluggable metric collectors.
-By default, this exporter listens on TCP port 9000, Path '/metrics', to expose metrics.
+By default, this exporter listens on TCP port 9177, path '/metrics', to expose metrics.
+
+This exporter is built upon the [go-libvirt](https://github.com/digitalocean/go-libvirt) package developed by DigitalOcean. It offers a pure Go interface for interacting with Libvirt, leveraging the RPC interface provided by Libvirt. For detailed information about the Go bindings used, you can refer to the [Libvirt API reference](https://libvirt.org/html/index.html).
+
+
 
 # Building and running
 
@@ -30,7 +34,7 @@ Name | Label |Description
 ---------|---------|-------------
 up||scraping libvirt's metrics state
 domains||get number of domains
-libvirt_domain_openstack_info | "domain", "instance_name", "instance_id", "flavor_name", "user_name", "user_id", "project_name", "project_id" | get the aggregated OpenStack metadata as label
+libvirt_openstack_domain_info | "domain", "instance_name", "instance_id", "flavor_name", "user_name", "user_id", "project_name", "project_id" | get the aggregated OpenStack metadata as label
 libvirt_domain_info | "domain", "os_type", "os_type_machine", "os_type_arch" | get the aggregated OpenStack metadata as label
 domain_state_code|"domain", "state_desc", "host"|code of the domain state,include state description
 maximum_memory_bytes|"domain", "host" | Maximum allowed memory of the domain, in bytes

--- a/README.md
+++ b/README.md
@@ -1,59 +1,54 @@
-# prometheus-libvirt-exporter
-prometheus-libvirt-exporter for host and vm metrics exposed for prometheus, written in Go with pluggable metric collectors.
-By default, this exporter listens on TCP port 9000,Path '/metrics',to expose metrics.vm's tags contain userId,userName,ProjectId,ProjectName.
 
-[![Build Status](https://travis-ci.org/zhangjianweibj/prometheus-libvirt-exporter.svg?branch=master)](https://travis-ci.org/zhangjianweibj/prometheus-libvirt-exporter)
-[![codecov](https://codecov.io/gh/zhangjianweibj/prometheus-libvirt-exporter/branch/master/graph/badge.svg)](https://codecov.io/gh/zhangjianweibj/prometheus-libvirt-exporter)
+# Prometheus-libvirt-exporter
+[![Build and Test](https://github.com/inovex/prometheus-libvirt-exporter/actions/workflows/build_and_test.yml/badge.svg)](https://github.com/inovex/prometheus-libvirt-exporter/actions/workflows/build_and_test.yml)
+[![Lint Go Code](https://github.com/inovex/prometheus-libvirt-exporter/actions/workflows/lint.yml/badge.svg)](https://github.com/inovex/prometheus-libvirt-exporter/actions/workflows/lint.yml)
+
+A prometheus-[libvirt](https://libvirt.org/)-exporter for host and vm metrics exposed for prometheus, written in Go with pluggable metric collectors.
+By default, this exporter listens on TCP port 9000, Path '/metrics', to expose metrics.
+
 # Building and running
 
+This release provides a set of assets for the prometheus-libvirt-exporter. It includes installation packages for various platforms (apk, deb, rpm) and the the binaries. Additionally, source code archives in both zip and tar.gz formats are available for download.
+
 ## Requirements
-1. Gorelease: `go install github.com/goreleaser/goreleaser`
+1. Gorelease: `go install github.com/goreleaser/goreleaser@latest`
 
 2. Taskfile: `go install github.com/go-task/task/v3/cmd/task@latest`
 
-## use go dep(depressed)
-1. install go dep
-
-2. cp $GOPATH/bin/dep /usr/bin/
-
-3. dep ensure
-
-4. go build prometheus-libvirt-exporter.go
-
-5. ./prometheus-libvirt-exporter
-
-## Building
+## Local Building
 1. Run `task build`
 
 2. Afterwards all packages, binaries and archives are available in the `dist/` folder
 
 ## To see all available configuration flags:
 
-./prometheus-libvirt-exporter -h
+`./prometheus-libvirt-exporter -h`
 
 
 ## metrics
 Name | Label |Description
 ---------|---------|-------------
-up|"host"|scraping libvirt's metrics state
-domains_number|"host"|get number of domains
-domain_state_code|"domain", "instanceName", "instanceId", "flavorName", "userName", "userId", "projectName", "projectId", "stateDesc", "host"|code of the domain state,include state description
-maximum_memory_bytes|"domain", "instanceName", "instanceId", "flavorName", "userName", "userId", "projectName", "projectId", "host"|Maximum allowed memory of the domain, in bytes
-memory_usage_bytes|"domain", "instanceName", "instanceId", "flavorName", "userName", "userId", "projectName", "projectId", "host"|Memory usage of the domain, in bytes
-virtual_cpus|"domain", "instanceName", "instanceId", "flavorName", "userName", "userId", "projectName", "projectId", "host"|Number of virtual CPUs for the domain
-cpu_time_seconds_total|"domain", "instanceName", "instanceId", "flavorName", "userName", "userId", "projectName", "projectId", "host"|Amount of CPU time used by the domain, in seconds
-read_bytes_total|"domain", "instanceName", "instanceId", "flavorName", "userName", "userId", "projectName", "projectId", "source_file", "target_device", "host"|Number of bytes read from a block device, in bytes
-read_requests_total|"domain", "instanceName", "instanceId", "flavorName", "userName", "userId", "projectName", "projectId", "source_file", "target_device", "host"|Number of read requests from a block device
-write_bytes_total|"domain", "instanceName", "instanceId", "flavorName", "userName", "userId", "projectName", "projectId", "source_file", "target_device", "host"|Number of bytes written from a block device, in bytes
-write_requests_total|"domain", "instanceName", "instanceId", "flavorName", "userName", "userId", "projectName", "projectId", "source_file", "target_device", "host"|Number of write requests from a block device
-receive_bytes_total|"domain", "instanceName", "instanceId", "flavorName", "userName", "userId", "projectName", "projectId", "source_bridge", "target_device", "host"|Number of bytes received on a network interface, in bytes
-receive_packets_total|"domain", "instanceName", "instanceId", "flavorName", "userName", "userId", "projectName", "projectId", "source_bridge", "target_device", "host"|Number of packets received on a network interface
-receive_errors_total|"domain", "instanceName", "instanceId", "flavorName", "userName", "userId", "projectName", "projectId", "source_bridge", "target_device", "host"|Number of packet receive errors on a network interface
-receive_drops_total|"domain", "instanceName", "instanceId", "flavorName", "userName", "userId", "projectName", "projectId", "source_bridge", "target_device", "host"|Number of packet receive drops on a network interface
-transmit_bytes_total|"domain", "instanceName", "instanceId", "flavorName", "userName", "userId", "projectName", "projectId", "source_bridge", "target_device", "host"|Number of bytes transmitted on a network interface, in bytes
-transmit_packets_total|"domain", "instanceName", "instanceId", "flavorName", "userName", "userId", "projectName", "projectId", "source_bridge", "target_device", "host"|Number of packets transmitted on a network interface
-transmit_errors_total|"domain", "instanceName", "instanceId", "flavorName", "userName", "userId", "projectName", "projectId", "source_bridge", "target_device", "host"|Number of packet transmit errors on a network interface
-transmit_drops_total|"domain", "instanceName", "instanceId", "flavorName", "userName", "userId", "projectName", "projectId", "source_bridge", "target_device", "host"|Number of packet transmit drops on a network interface
+up||scraping libvirt's metrics state
+domains||get number of domains
+libvirt_domain_openstack_info | "domain", "instance_name", "instance_id", "flavor_name", "user_name", "user_id", "project_name", "project_id" | get the aggregated OpenStack metadata as label
+libvirt_domain_info | "domain", "os_type", "os_type_machine", "os_type_arch" | get the aggregated OpenStack metadata as label
+domain_state_code|"domain", "state_desc", "host"|code of the domain state,include state description
+maximum_memory_bytes|"domain", "host" | Maximum allowed memory of the domain, in bytes
+memory_usage_bytes|"domain", "host"|Memory usage of the domain, in bytes
+virtual_cpus|"domain", "host"|Number of virtual CPUs for the domain
+cpu_time_seconds_total|"domain", "host"|Amount of CPU time used by the domain, in seconds
+read_bytes_total|"domain", "source_file", "target_device", "host"|Number of bytes read from a block device, in bytes
+read_requests_total|"domain", "source_file", "target_device", "host"|Number of read requests from a block device
+write_bytes_total|"domain", "source_file", "target_device" | Number of bytes written from a block device, in bytes
+write_requests_total|"domain", "source_file", "target_device" | Number of write requests from a block device
+receive_bytes_total|"domain", "source_bridge", "target_device", | Number of bytes received on a network interface, in bytes
+receive_packets_total|"domain", "source_bridge", "target_device" | Number of packets received on a network interface
+receive_errors_total|"domain", "source_bridge", "target_device" | Number of packet receive errors on a network interface
+receive_drops_total|"domain", "source_bridge", "target_device" | Number of packet receive drops on a network interface
+transmit_bytes_total|"domain", "source_bridge", "target_device" | Number of bytes transmitted on a network interface, in bytes
+transmit_packets_total|"domain", "source_bridge", "target_device" | Number of packets transmitted on a network interface
+transmit_errors_total|"domain", "source_bridge", "target_device" | Number of packet transmit errors on a network interface
+transmit_drops_total|"domain", "source_bridge", "target_device" | Number of packet transmit drops on a network interface
 
 
 ## Example

--- a/debian/prometheus-libvirt-exporter.service
+++ b/debian/prometheus-libvirt-exporter.service
@@ -4,7 +4,7 @@ Requires=network-online.target
 After=network-online.target
 
 [Service]
-ExecStart=/usr/bin/prometheus-libvirt-exporter --web.listen-address ":9180"
+ExecStart=/usr/bin/prometheus-libvirt-exporter --web.listen-address ":9177"
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 KillSignal=SIGINT

--- a/debian/prometheus-libvirt-exporter.upstart
+++ b/debian/prometheus-libvirt-exporter.upstart
@@ -7,7 +7,7 @@ respawn
 
 script
    echo $$ > /var/run/prometheus-libvirt-exporter.pid
-   exec prometheus-libvirt-exporter --web.listen-address ":9180"
+   exec prometheus-libvirt-exporter --web.listen-address ":9177"
 end script
 
 post-stop script

--- a/libvirt_schema/schema.go
+++ b/libvirt_schema/schema.go
@@ -3,24 +3,25 @@ package libvirt_schema
 import "encoding/xml"
 
 type Domain struct {
-	Devices           Devices           `xml:"devices"`
-	Name              string            `xml:"name"`
-	UUID              string            `xml:"uuid"`
-	Metadata          Metadata          `xml:"metadata"`
-	OpenStackMetadata OpenStackMetadata `xml:"os"`
+	Devices    Devices    `xml:"devices"`
+	Name       string     `xml:"name"`
+	UUID       string     `xml:"uuid"`
+	Metadata   Metadata   `xml:"metadata"`
+	OSMetadata OSMetadata `xml:"os"`
 }
 
 type Metadata struct {
 	NovaInstance NovaInstance `xml:"instance"`
 }
 
-type OpenStackMetadata struct {
-	Type OpenStackType `xml:"type"`
+type OSMetadata struct {
+	Type OSType `xml:"type"`
 }
 
-type OpenStackType struct {
+type OSType struct {
 	Arch    string `xml:"arch,attr"`
 	Machine string `xml:"machine,attr"`
+	Value   string `xml:",chardata"`
 }
 
 type NovaInstance struct {

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 	metricsPath := kingpin.Flag(
 		"web.telemetry-path", "Path under which to expose metrics",
 	).Default("/metrics").String()
-	toolkitFlags := webflag.AddFlags(kingpin.CommandLine, ":9000")
+	toolkitFlags := webflag.AddFlags(kingpin.CommandLine, ":9177")
 
 	promlogConfig := &promlog.Config{}
 	flag.AddFlags(kingpin.CommandLine, promlogConfig)

--- a/pkg/exporter/prometheus-libvirt-exporter.go
+++ b/pkg/exporter/prometheus-libvirt-exporter.go
@@ -12,137 +12,152 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const namespace = "libvirt"
+
 var (
 	libvirtUpDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("libvirt", "", "up"),
+		prometheus.BuildFQName(namespace, "", "up"),
 		"Whether scraping libvirt's metrics was successful.",
-		[]string{"host"},
+		nil,
 		nil)
 
 	libvirtDomainNumbers = prometheus.NewDesc(
-		prometheus.BuildFQName("libvirt", "", "domains_number"),
-		"Number of the domain",
-		[]string{"host"},
+		prometheus.BuildFQName(namespace, "", "domains"),
+		"Number of domains",
+		nil,
 		nil)
 
 	libvirtDomainState = prometheus.NewDesc(
-		prometheus.BuildFQName("libvirt", "", "domain_state_code"),
+		prometheus.BuildFQName(namespace, "", "domain_state_code"),
 		"Code of the domain state",
-		[]string{"domain", "instanceName", "instanceId", "flavorName", "arch", "machine", "userName", "userId", "projectName", "projectId", "host", "stateDesc"},
+		[]string{"domain", "state_desc"},
 		nil)
 
 	libvirtDomainInfoMaxMemDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("libvirt", "domain_info", "maximum_memory_bytes"),
+		prometheus.BuildFQName(namespace, "domain_info", "maximum_memory_bytes"),
 		"Maximum allowed memory of the domain, in bytes.",
-		[]string{"domain", "instanceName", "instanceId", "flavorName", "arch", "machine", "userName", "userId", "projectName", "projectId", "host"},
+		[]string{"domain"},
 		nil)
 	libvirtDomainInfoMemoryDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("libvirt", "domain_info", "memory_usage_bytes"),
+		prometheus.BuildFQName(namespace, "domain_info", "memory_usage_bytes"),
 		"Memory usage of the domain, in bytes.",
-		[]string{"domain", "instanceName", "instanceId", "flavorName", "arch", "machine", "userName", "userId", "projectName", "projectId", "host"},
+		[]string{"domain"},
 		nil)
 	libvirtDomainStatMemorySwapInBytesDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("libvirt", "domain_stat", "memory_swap_in_bytes"),
+		prometheus.BuildFQName(namespace, "domain_stat", "memory_swap_in_bytes"),
 		"Memory swap in of domain(the total amount of data read from swap space), in bytes.",
-		[]string{"domain", "instanceName", "instanceId", "flavorName", "arch", "machine", "userName", "userId", "projectName", "projectId", "host"},
+		[]string{"domain"},
 		nil)
 	libvirtDomainStatMemorySwapOutBytesDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("libvirt", "domain_stat", "memory_swap_out_bytes"),
+		prometheus.BuildFQName(namespace, "domain_stat", "memory_swap_out_bytes"),
 		"Memory swap out of the domain(the total amount of memory written out to swap space), in bytes.",
-		[]string{"domain", "instanceName", "instanceId", "flavorName", "arch", "machine", "userName", "userId", "projectName", "projectId", "host"},
+		[]string{"domain"},
 		nil)
 	libvirtDomainStatMemoryUnusedBytesDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("libvirt", "domain_stat", "memory_unused_bytes"),
+		prometheus.BuildFQName(namespace, "domain_stat", "memory_unused_bytes"),
 		"Memory unused of the domain, in bytes.",
-		[]string{"domain", "instanceName", "instanceId", "flavorName", "arch", "machine", "userName", "userId", "projectName", "projectId", "host"},
+		[]string{"domain"},
 		nil)
 	libvirtDomainStatMemoryAvailableInBytesDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("libvirt", "domain_stat", "memory_available_bytes"),
+		prometheus.BuildFQName(namespace, "domain_stat", "memory_available_bytes"),
 		"Memory available of the domain, in bytes.",
-		[]string{"domain", "instanceName", "instanceId", "flavorName", "arch", "machine", "userName", "userId", "projectName", "projectId", "host"},
+		[]string{"domain"},
 		nil)
 	libvirtDomainStatMemoryUsableBytesDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("libvirt", "domain_stat", "memory_usable_bytes"),
+		prometheus.BuildFQName(namespace, "domain_stat", "memory_usable_bytes"),
 		"Memory usable of the domain(corresponds to 'Available' in /proc/meminfo), in bytes.",
-		[]string{"domain", "instanceName", "instanceId", "flavorName", "arch", "machine", "userName", "userId", "projectName", "projectId", "host"},
+		[]string{"domain"},
 		nil)
 	libvirtDomainStatMemoryRssBytesDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("libvirt", "domain_stat", "memory_rss_bytes"),
+		prometheus.BuildFQName(namespace, "domain_stat", "memory_rss_bytes"),
 		"Resident Set Size of the process running the domain, in bytes.",
-		[]string{"domain", "instanceName", "instanceId", "flavorName", "arch", "machine", "userName", "userId", "projectName", "projectId", "host"},
+		[]string{"domain"},
 		nil)
 	libvirtDomainInfoNrVirtCpuDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("libvirt", "domain_info", "virtual_cpus"),
+		prometheus.BuildFQName(namespace, "domain_info", "virtual_cpus"),
 		"Number of virtual CPUs for the domain.",
-		[]string{"domain", "instanceName", "instanceId", "flavorName", "arch", "machine", "userName", "userId", "projectName", "projectId", "host"},
+		[]string{"domain"},
 		nil)
 	libvirtDomainInfoCpuTimeDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("libvirt", "domain_info", "cpu_time_seconds_total"),
+		prometheus.BuildFQName(namespace, "domain_info", "cpu_time_seconds_total"),
 		"Amount of CPU time used by the domain, in seconds.",
-		[]string{"domain", "instanceName", "instanceId", "flavorName", "arch", "machine", "userName", "userId", "projectName", "projectId", "host"},
+		[]string{"domain"},
 		nil)
 
 	libvirtDomainBlockRdBytesDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("libvirt", "domain_block_stats", "read_bytes_total"),
+		prometheus.BuildFQName(namespace, "domain_block_stats", "read_bytes_total"),
 		"Number of bytes read from a block device, in bytes.",
-		[]string{"domain", "instanceName", "instanceId", "flavorName", "arch", "machine", "userName", "userId", "projectName", "projectId", "host", "source_file", "target_device"},
+		[]string{"domain", "source_file", "target_device"},
 		nil)
 	libvirtDomainBlockRdReqDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("libvirt", "domain_block_stats", "read_requests_total"),
+		prometheus.BuildFQName(namespace, "domain_block_stats", "read_requests_total"),
 		"Number of read requests from a block device.",
-		[]string{"domain", "instanceName", "instanceId", "flavorName", "arch", "machine", "userName", "userId", "projectName", "projectId", "host", "source_file", "target_device"},
+		[]string{"domain", "source_file", "target_device"},
 		nil)
 	libvirtDomainBlockWrBytesDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("libvirt", "domain_block_stats", "write_bytes_total"),
+		prometheus.BuildFQName(namespace, "domain_block_stats", "write_bytes_total"),
 		"Number of bytes written from a block device, in bytes.",
-		[]string{"domain", "instanceName", "instanceId", "flavorName", "arch", "machine", "userName", "userId", "projectName", "projectId", "host", "source_file", "target_device"},
+		[]string{"domain", "source_file", "target_device"},
 		nil)
 	libvirtDomainBlockWrReqDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("libvirt", "domain_block_stats", "write_requests_total"),
+		prometheus.BuildFQName(namespace, "domain_block_stats", "write_requests_total"),
 		"Number of write requests from a block device.",
-		[]string{"domain", "instanceName", "instanceId", "flavorName", "arch", "machine", "userName", "userId", "projectName", "projectId", "host", "source_file", "target_device"},
+		[]string{"domain", "source_file", "target_device"},
 		nil)
 
 	//DomainInterface
 	libvirtDomainInterfaceRxBytesDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("libvirt", "domain_interface_stats", "receive_bytes_total"),
+		prometheus.BuildFQName(namespace, "domain_interface_stats", "receive_bytes_total"),
 		"Number of bytes received on a network interface, in bytes.",
-		[]string{"domain", "instanceName", "instanceId", "flavorName", "arch", "machine", "userName", "userId", "projectName", "projectId", "host", "source_bridge", "target_device"},
+		[]string{"domain", "source_bridge", "target_device"},
 		nil)
 	libvirtDomainInterfaceRxPacketsDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("libvirt", "domain_interface_stats", "receive_packets_total"),
+		prometheus.BuildFQName(namespace, "domain_interface_stats", "receive_packets_total"),
 		"Number of packets received on a network interface.",
-		[]string{"domain", "instanceName", "instanceId", "flavorName", "arch", "machine", "userName", "userId", "projectName", "projectId", "host", "source_bridge", "target_device"},
+		[]string{"domain", "source_bridge", "target_device"},
 		nil)
 	libvirtDomainInterfaceRxErrsDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("libvirt", "domain_interface_stats", "receive_errors_total"),
+		prometheus.BuildFQName(namespace, "domain_interface_stats", "receive_errors_total"),
 		"Number of packet receive errors on a network interface.",
-		[]string{"domain", "instanceName", "instanceId", "flavorName", "arch", "machine", "userName", "userId", "projectName", "projectId", "host", "source_bridge", "target_device"},
+		[]string{"domain", "source_bridge", "target_device"},
 		nil)
 	libvirtDomainInterfaceRxDropDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("libvirt", "domain_interface_stats", "receive_drops_total"),
+		prometheus.BuildFQName(namespace, "domain_interface_stats", "receive_drops_total"),
 		"Number of packet receive drops on a network interface.",
-		[]string{"domain", "instanceName", "instanceId", "flavorName", "arch", "machine", "userName", "userId", "projectName", "projectId", "host", "source_bridge", "target_device"},
+		[]string{"domain", "source_bridge", "target_device"},
 		nil)
 	libvirtDomainInterfaceTxBytesDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("libvirt", "domain_interface_stats", "transmit_bytes_total"),
+		prometheus.BuildFQName(namespace, "domain_interface_stats", "transmit_bytes_total"),
 		"Number of bytes transmitted on a network interface, in bytes.",
-		[]string{"domain", "instanceName", "instanceId", "flavorName", "arch", "machine", "userName", "userId", "projectName", "projectId", "host", "source_bridge", "target_device"},
+		[]string{"domain", "source_bridge", "target_device"},
 		nil)
 	libvirtDomainInterfaceTxPacketsDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("libvirt", "domain_interface_stats", "transmit_packets_total"),
+		prometheus.BuildFQName(namespace, "domain_interface_stats", "transmit_packets_total"),
 		"Number of packets transmitted on a network interface.",
-		[]string{"domain", "instanceName", "instanceId", "flavorName", "arch", "machine", "userName", "userId", "projectName", "projectId", "host", "source_bridge", "target_device"},
+		[]string{"domain", "source_bridge", "target_device"},
 		nil)
 	libvirtDomainInterfaceTxErrsDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("libvirt", "domain_interface_stats", "transmit_errors_total"),
+		prometheus.BuildFQName(namespace, "domain_interface_stats", "transmit_errors_total"),
 		"Number of packet transmit errors on a network interface.",
-		[]string{"domain", "instanceName", "instanceId", "flavorName", "arch", "machine", "userName", "userId", "projectName", "projectId", "host", "source_bridge", "target_device"},
+		[]string{"domain", "source_bridge", "target_device"},
 		nil)
 	libvirtDomainInterfaceTxDropDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("libvirt", "domain_interface_stats", "transmit_drops_total"),
+		prometheus.BuildFQName(namespace, "domain_interface_stats", "transmit_drops_total"),
 		"Number of packet transmit drops on a network interface.",
-		[]string{"domain", "instanceName", "instanceId", "flavorName", "arch", "machine", "userName", "userId", "projectName", "projectId", "host", "source_bridge", "target_device"},
+		[]string{"domain", "source_bridge", "target_device"},
+		nil)
+
+	// info metrics
+	libvirtOpenstackDomainInfoDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "openstack", "domain_info"),
+		"Metadata labels for the domain.",
+		[]string{"domain", "instance_name", "instance_id", "flavor_name", "user_name", "user_id", "project_name", "project_id"},
+		nil)
+
+	libvirtDomainInfoDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "domain_info"),
+		"OpenStack Metadata labels for the domain.",
+		[]string{"domain", "os_type", "os_type_arch", "os_type_machine"},
 		nil)
 
 	domainState = map[libvirt_schema.DomainState]string{
@@ -161,12 +176,13 @@ var (
 type collectFunc func(ch chan<- prometheus.Metric, l *libvirt.Libvirt, domain domainMeta, promLabels []string, logger log.Logger) (err error)
 
 type domainMeta struct {
-	domainName   string
-	instanceName string
-	instanceId   string
-	flavorName   string
-	arch         string
-	machine      string
+	domainName      string
+	instanceName    string
+	instanceId      string
+	flavorName      string
+	os_type_arch    string
+	os_type_machine string
+	os_type         string
 
 	userName string
 	userId   string
@@ -223,8 +239,9 @@ func DomainsFromLibvirt(l *libvirt.Libvirt, logger log.Logger) ([]domainMeta, er
 		lvDomains[idx].instanceName = libvirtSchema.Metadata.NovaInstance.Name
 		lvDomains[idx].instanceId = libvirtSchema.UUID
 		lvDomains[idx].flavorName = libvirtSchema.Metadata.NovaInstance.Flavor.FlavorName
-		lvDomains[idx].arch = libvirtSchema.OpenStackMetadata.Type.Arch
-		lvDomains[idx].machine = libvirtSchema.OpenStackMetadata.Type.Machine
+		lvDomains[idx].os_type_arch = libvirtSchema.OSMetadata.Type.Arch
+		lvDomains[idx].os_type_machine = libvirtSchema.OSMetadata.Type.Machine
+		lvDomains[idx].os_type = libvirtSchema.OSMetadata.Type.Value
 
 		lvDomains[idx].userName = libvirtSchema.Metadata.NovaInstance.Owner.User.UserName
 		lvDomains[idx].userId = libvirtSchema.Metadata.NovaInstance.Owner.User.UserId
@@ -266,17 +283,10 @@ func CollectFromLibvirt(ch chan<- prometheus.Metric, uri string, driver libvirt.
 		}
 	}()
 
-	var host string
-	if host, err = l.ConnectGetHostname(); err != nil {
-		_ = level.Error(logger).Log("err", "failed to get hostname")
-		return err
-	}
-
 	ch <- prometheus.MustNewConstMetric(
 		libvirtUpDesc,
 		prometheus.GaugeValue,
-		1.0,
-		host)
+		1.0)
 
 	domains, err := DomainsFromLibvirt(l, logger)
 
@@ -284,8 +294,7 @@ func CollectFromLibvirt(ch chan<- prometheus.Metric, uri string, driver libvirt.
 	ch <- prometheus.MustNewConstMetric(
 		libvirtDomainNumbers,
 		prometheus.GaugeValue,
-		float64(domainNumber),
-		host)
+		float64(domainNumber))
 
 	for _, domain := range domains {
 		if err = CollectDomain(ch, l, domain, logger); err != nil {
@@ -298,11 +307,6 @@ func CollectFromLibvirt(ch chan<- prometheus.Metric, uri string, driver libvirt.
 
 // CollectDomain extracts Prometheus metrics from a libvirt domain.
 func CollectDomain(ch chan<- prometheus.Metric, l *libvirt.Libvirt, domain domainMeta, logger log.Logger) (err error) {
-	var host string
-	if host, err = l.ConnectGetHostname(); err != nil {
-		_ = level.Error(logger).Log("err", "failed to get hostname")
-		return err
-	}
 
 	var rState uint8
 	var rvirCpu uint16
@@ -312,18 +316,26 @@ func CollectDomain(ch chan<- prometheus.Metric, l *libvirt.Libvirt, domain domai
 		return err
 	}
 
-	promLabels := []string{
+	promLabels := []string{}
+
+	openstackInfoLabels := []string{
 		domain.domainName,
 		domain.instanceName,
 		domain.instanceId,
 		domain.flavorName,
-		domain.arch,
-		domain.machine,
 		domain.userName,
 		domain.userId,
 		domain.projectName,
 		domain.projectId,
-		host}
+	}
+	infoLabels := []string{
+		domain.os_type,
+		domain.os_type_arch,
+		domain.os_type_machine,
+	}
+
+	ch <- prometheus.MustNewConstMetric(libvirtDomainInfoDesc, prometheus.GaugeValue, 1.0, infoLabels...)
+	ch <- prometheus.MustNewConstMetric(libvirtOpenstackDomainInfoDesc, prometheus.GaugeValue, 1.0, openstackInfoLabels...)
 
 	ch <- prometheus.MustNewConstMetric(libvirtDomainState, prometheus.GaugeValue, float64(rState), append(promLabels, domainState[libvirt_schema.DomainState(rState)])...)
 
@@ -511,6 +523,9 @@ func CollectDomainDomainStatInfo(ch chan<- prometheus.Metric, l *libvirt.Libvirt
 func (e *LibvirtExporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- libvirtUpDesc
 	ch <- libvirtDomainNumbers
+
+	ch <- libvirtDomainInfoDesc
+	ch <- libvirtOpenstackDomainInfoDesc
 
 	//domain info
 	ch <- libvirtDomainState

--- a/pkg/exporter/prometheus-libvirt-exporter_test.go
+++ b/pkg/exporter/prometheus-libvirt-exporter_test.go
@@ -158,6 +158,9 @@ func TestUnmarshal(t *testing.T) {
 	}
 	assert.Equal(nil, r.Metadata.NovaInstance.Name, "LqnyzNfe")
 	assert.Equal(nil, r.Metadata.NovaInstance.Flavor.FlavorName, "c1.micro")
+	assert.Equal(nil, r.OSMetadata.Type.Value, "hvm")
+	assert.Equal(nil, r.OSMetadata.Type.Machine, "pc-i440fx-rhel7.3.0")
+	assert.Equal(nil, r.OSMetadata.Type.Arch, "x86_64")
 	fmt.Printf("xml name=%#v\n", r.Metadata.NovaInstance.XMLName)
 	fmt.Printf("nova name=%#v\n", r.Metadata.NovaInstance.Name)
 	fmt.Printf("nova =%#v\n", r.Metadata)


### PR DESCRIPTION
 I added the `libvirt_domain_info` and `libvirt_openstack_domain_info` metrics and assigned all labels not necessary for the metics itself. All labels are streamlined. I updated the labels to be snake case. Additionally the README was cleaned up and updated.